### PR TITLE
Enable docker experimental

### DIFF
--- a/packer/test-cluster.json
+++ b/packer/test-cluster.json
@@ -28,10 +28,13 @@
       "sudo add-apt-repository -y ppa:openjdk-r/ppa",
       "sudo apt-get update",
       "sudo apt-get install -y docker-ce",
+      "sudo mkdir $HOME/.docker",
+      "sudo echo '{"experimental": "enabled"}' | tee $HOME/.docker/config.json",
       "sudo usermod -aG docker ubuntu",
       "sudo curl -L https://github.com/docker/compose/releases/download/1.15.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose",
       "sudo chmod +x /usr/local/bin/docker-compose",
-      "sudo apt-get install -y openjdk-8-jdk"
+      "sudo apt-get install -y openjdk-8-jdk",
+      "sudo service docker restart"
     ]
   }]
 }


### PR DESCRIPTION
Enable docker experimental through config.json to get access to docker manifest command

@vfarcic, please confirm if the docker manifest command is available after this PR.

Running this command:
```
docker manifest inspect dockerflow/docker-flow-proxy
```

Should show result like this:
```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3027,
         "digest": "sha256:cdf55a4e5c4b5f3689f0f1cc79fca4d47745ce3617a7fcefb09d1e4833e5f9b8",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3034,
         "digest": "sha256:6a1fbf9a01dde7c79ee2afa4c23448c32254626aa7f718b6f15416e85205f8ac",
         "platform": {
            "architecture": "arm",
            "os": "linux"
         }
      }
   ]
}
```